### PR TITLE
スポンサーロゴがAdBlockされる問題を修正

### DIFF
--- a/assets/css/conference.css
+++ b/assets/css/conference.css
@@ -379,7 +379,7 @@ figcaption {
   width: 80%;
   display: inline-block;
 }
-.sponsor-logo{
+.sponsor-img{
   display:inline-block;
 }
 .sponsor-img-l,
@@ -478,7 +478,7 @@ figcaption {
     width: 40%;
   }
 
-  .sponsor-logo {
+  .sponsor-img {
     display:block;
   }
 

--- a/conference2016/index.html
+++ b/conference2016/index.html
@@ -362,7 +362,7 @@
   <br>
   <h3 class="sub-heading">Diamond</h3>
   <br>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://www.microsoft.com/ja-jp/">
       <img class="sponsor-img-l" src="../images/conference2016/sponsor/microsoft.png" alt="Microsoft" title="Microsoft">
     </a>
@@ -370,33 +370,33 @@
   <br>
   <h3 class="sub-heading">Sapphire</h3>
   <br>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://github.com/about"><img class="sponsor-img-m" src="../images/conference2016/sponsor/GitHub.png" alt="GitHub" title="GitHub"></a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://www.happycom.co.jp/aboutus/"><img class="sponsor-img-m" src="../images/conference2016/sponsor/happyDigital.png" alt="ハッピーコム" title="ハッピーコム"></a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="http://www.bbs.co.jp/">
       <img class="sponsor-img-m" src="../images/conference2016/sponsor/bbs.png" alt="株式会社ビジネスブレイン太田昭和（BBS）" title="株式会社ビジネスブレイン太田昭和（BBS）">
     </a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="http://www.atware.co.jp/#sprits">
       <img class="sponsor-img-m" src="../images/conference2016/sponsor/atware.png" alt="アットウェア" title="アットウェア">
     </a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://www.pasonatech.co.jp/">
       <img class="sponsor-img-m" src="../images/conference2016/sponsor/PasonaTech.jpg" alt="パソナテック" title="パソナテック">
     </a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://www.atlassian.com/">
       <img class="sponsor-img-m" src="../images/conference2016/sponsor/atlassian.png" alt="Atlassian" title="Atlassian">
     </a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="http://gxp.co.jp/">
       <img class="sponsor-img-m" src="../images/conference2016/sponsor/gxp.png" alt="グロースエクスパートナーズ株式会社" title="グロースエクスパートナーズ株式会社">
     </a>
@@ -404,15 +404,15 @@
   <br>
   <h3 class="sub-heading">Emerald</h3>
   <br>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://www.paypal.com/jp/webapps/mpp/home">
       <img class="sponsor-img-s" src="../images/conference2016/sponsor/paypal.png" alt="PayPal" title="PayPal">
     </a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="http://focusrite.in/"><img class="sponsor-img-s" src="../images/conference2016/sponsor/focusrite.png" alt="focusrite" title="focusrite"></a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="http://www.serverworks.co.jp/">
       <img class="sponsor-img-s" src="../images/conference2016/sponsor/serverworks.png" alt="サーバーワークス" title="サーバーワークス">
     </a>
@@ -420,22 +420,22 @@
   <br>
   <h3 class="sub-heading">Quartz</h3>
   <br>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="http://spicelife.jp/">
       <img src="../images/conference2016/sponsor/spicelife.png" alt="spicelife" title="spicelife" class="sponsor-img-s">
     </a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://tmix.jp/">
       <img src="../images/conference2016/sponsor/tmix.png" alt="TMIX" title="TMIX" class="sponsor-img-s">
     </a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://www.oisix.com/OtameshiTouroku.lp.g6--top--top-shinki_domo_b__html.htm?null">
       <img src="../images/conference2016/sponsor/Oisix.png" alt="Oisix" title="Oisix" class="sponsor-img-s">
     </a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://www.salesforce.com/jp/">
       <img src="../images/conference2016/sponsor/salesforce.png" alt="salesforce" title="salesforce" class="sponsor-img-s">
     </a>
@@ -443,10 +443,10 @@
   <br>
   <h3 class="sub-heading">Amber</h3>
   <br>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="https://www.happycom.co.jp/"><img class="sponsor-img-s" src="../images/conference2016/sponsor/happyDigital.png" alt="Happyデジタル" title="Happyデジタル"></a>
   </div>
-  <div class="sponsor-logo">
+  <div class="sponsor-img">
     <a href="http://classmethod.jp/"><img class="sponsor-img-s" src="../images/conference2016/sponsor/classmethod.png" alt="クラスメソッド株式会社" title="クラスメソッド株式会社"></a>
   </div>
   <br>


### PR DESCRIPTION
通りすがりのものです。
Chrome拡張機能などのAdBlockPlusで、[EasyList](https://easylist.to/)というリストを入れていると、 `.sponsor-logo` が `display:none` されてしまう問題があるようです。（画像参照）

![2017-03-27 1 49 39](https://cloud.githubusercontent.com/assets/1075914/24333255/b30182d4-128f-11e7-891a-b390216ea84e.png)

なので、 `.sponsor-logo` を `.sponsor-img` にリネームしてみました。いかがでしょうか。